### PR TITLE
Allow granular override of enabled_zones

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,26 @@ Use `Pipenv` and `.python-version` files to know the required libraries to run t
 Role Variables
 --------------
 
-- `trusted_sources`: list of IPs that you want to enable access over the trusted firewalld zone.
-- `trusted_services`: list of defined services you want to enable for the trusted firewalld zone.
-- `public_services`: list of defined services you want to enable for the public firewalld zone.
+### Internal Zone
+- `internal_services`: list of defined services you want to enable for the internal firewalld zone. Defaults to `[]`
+- `internal_sources`: list of IPs that you want to enable access over the internal firewalld zone. Defaults to `[]`
+- `internal_ports`: list of ports that you want to enable access to over the internal firewalld zone. Defaults to `[]`
+- `internal_rich_rules`: list of rich rules you want to enable for the internal firewalld zone. Defaults to `[]`
 
+### Trusted Zone
+- `trusted_services`: list of defined services you want to enable for the trusted firewalld zone. Defaults to `[]`
+- `trusted_sources`: list of IPs that you want to enable access over the trusted firewalld zone. Defaults to `[]`
+- `trusted_ports`: list of ports that you want to enable access to over the trusted firewalld zone. Defaults to `[]`
+- `trusted_rich_rules`: list of rich rules you want to enable for the trusted firewalld zone. Defaults to `[]`
+
+
+### Public Zone
+- `public_services`: list of defined services you want to enable for the public firewalld zone. Defaults to `[]`
+- `public_ports`: list of ports that you want to enable access to over the public firewalld zone. Defaults to `[]`
+- `public_rich_rules`: list of rich rules you want to enable for the public firewalld zone. Defaults to `[]`
+- `public_sources`: list of IPs that you want to enable access over the public firewalld zone. Defaults to `[]`
+
+[Docs on firewalld zones](https://firewalld.org/documentation/man-pages/firewalld.zones.html)
 
 Dependencies
 ------------
@@ -26,20 +42,13 @@ This role requires no other roles or libraries. It works through the `firewalld`
 Example Playbook
 ----------------
 
-Including an example of how to use your role (for instance, with variables
-passed in as parameters) is always nice for users too:
-
     - hosts: servers
       roles:
-         - { role: networking, x: 42 }
+         - role: networking
+           public_services: https
+
 
 License
 -------
 
 BSD
-
-Author Information
-------------------
-
-An optional section for the role authors to include contact information, or a
-website (HTML is not allowed).

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,19 +1,33 @@
 ---
 # defaults file for networking
 
+trusted_sources: []
+trusted_services: []
+trusted_ports: []
+trusted_rich_rules: []
+internal_sources: []
+internal_services: []
+internal_ports: []
+internal_rich_rules: []
+public_sources: []
+public_services: []
+public_ports: []
+public_rich_rules: []
+
+
 enabled_zones:
   trusted:
-    sources: []
-    services: []
-    ports: []
-    rich_rules: []
+    sources: "{{ trusted_sources }}"
+    services: "{{ trusted_services }}"
+    ports: "{{ trusted_ports }}"
+    rich_rules: "{{ trusted_rich_rules }}"
   internal:
-    sources: []
-    services: []
-    ports: []
-    rich_rules: []
+    sources: "{{ internal_sources }}"
+    services: "{{ internal_services }}"
+    ports: "{{ internal_ports }}"
+    rich_rules: "{{ internal_rich_rules }}"
   public:
-    sources: []
-    services: []
-    ports: []
-    rich_rules: []
+    sources: "{{ public_sources }}"
+    services: "{{ public_services }}"
+    ports: "{{ public_ports }}"
+    rich_rules: "{{ public_rich_rules }}"


### PR DESCRIPTION
Defines a variables for each attribute of each zone in enabled_zones so
that the individual attribute can be overridden without needing to copy
the entire structure and all of it's defaults.